### PR TITLE
Fix MediaStream deprecation. Refs #2

### DIFF
--- a/src/tinyMEDIA/src/tmedia_session_jsep.js
+++ b/src/tinyMEDIA/src/tmedia_session_jsep.js
@@ -371,7 +371,9 @@ tmedia_session_jsep.prototype.close = function () {
             // TODO: On Firefox 26: Error: "removeStream not implemented yet"
             try { this.o_pc.removeStream(this.o_local_stream); } catch (e) { }
             if(!this.b_cache_stream || (this.e_type == tmedia_type_e.SCREEN_SHARE)) { // only stop if caching is disabled or screenshare
-                this.o_local_stream.stop();
+                this.o_local_stream.getTracks().forEach(function (track) {
+                    track.stop();
+                });
             }
             this.o_local_stream = null;
         }


### PR DESCRIPTION
MediaStream deprecated MediaStream.stop() method https://developers.google.com/web/updates/2015/07/mediastream-deprecations as described here https://github.com/sipml5/sipml5/issues/2
